### PR TITLE
Update prompt colour to magenta

### DIFF
--- a/src/repl.jl
+++ b/src/repl.jl
@@ -41,7 +41,7 @@ function create_test_repl_mode(repl::AbstractREPL, main::LineEdit.Prompt)
     test_mode = LineEdit.Prompt(
         test_mode_prompt;
         complete=REPL.REPLCompletionProvider(),
-        prompt_prefix=repl.options.hascolor ? Base.text_colors[:white] : "",
+        prompt_prefix=repl.options.hascolor ? Base.text_colors[:magenta] : "",
         prompt_suffix="",
         sticky=true,
     )


### PR DESCRIPTION
The `test>` prompt colour (white) is not easily readable for light themes:

![light-white](https://github.com/user-attachments/assets/68da009e-60e2-48aa-a05e-a1206113a74a)

This PR proposes to use `Base.text_colors[:magenta]` instead, which shows up nicely for both light and dark themes:

![dark_magenta](https://github.com/user-attachments/assets/9394e115-e229-4143-8f0c-e5ddbd5fb7c5)
![light_magenta](https://github.com/user-attachments/assets/d1dcf1fc-9a17-45c2-9d29-9a7e7bfbb4ae)

Fixes #5 