### PR TITLE
Use version of ctx_and_pkgspec not instantiating

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TestPicker"
 uuid = "a64165b9-4409-4de6-85cd-a4e0953bae44"
 authors = ["theogf <theo.galyfajou@gmail.com> and contributors"]
-version = "0.1.0"
+version = "0.1.1"
 
 [deps]
 JuliaSyntax = "70703baa-626e-46a2-a12c-08ffd08c73b4"

--- a/src/TestPicker.jl
+++ b/src/TestPicker.jl
@@ -6,8 +6,10 @@ using REPL
 using REPL: LineEdit
 using JuliaSyntax
 using TestEnv
-using TestEnv: current_pkg_name, get_test_dir, ctx_and_pkgspec
+using TestEnv: current_pkg_name, get_test_dir, isinstalled!
 using Pkg
+using Pkg: PackageSpec
+using Pkg.Types: Context
 using Test
 
 include("eval.jl")

--- a/src/testfile.jl
+++ b/src/testfile.jl
@@ -37,7 +37,10 @@ the collection of test files as paths relative to it.
 """
 function get_test_files()
     pkg = current_pkg_name()
-    test_dir = get_test_dir(ctx_and_pkgspec(pkg)...)
+    pkgspec = deepcopy(PackageSpec(pkg))
+    ctx = Context()
+    isinstalled!(ctx, pkgspec) || throw(ArgumentError("$pkg not installed 👻"))
+    test_dir = get_test_dir(ctx, pkgspec)
     isdir(test_dir) || error(
         "the test directory $(test_dir) does not exist, you need to activate your package environment first",
     )


### PR DESCRIPTION
Every call to `test_file` was instantiating due to `ctx_and_pkg` calling `instantiate`