### PR TITLE
Add small headers and stop using deprecated version from binaries

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -13,7 +13,6 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 TestEnv = "1e6cf692-eddd-4d53-88a5-2d735e33781b"
 bat_jll = "e1736374-6498-5d90-ab12-e7e58ba27d07"
 fzf_jll = "214eeab7-80f7-51ab-84ad-2988db7cef09"
-ripgrep_jll = "e10fc14b-37cd-5cbc-b289-ad01b12ebaad"
 
 [compat]
 InteractiveUtils = "1"

--- a/src/TestPicker.jl
+++ b/src/TestPicker.jl
@@ -1,6 +1,6 @@
 module TestPicker
 
-using bat_jll: bat
+using bat_jll: get_bat_path
 using fzf_jll: fzf
 using JuliaSyntax
 using InteractiveUtils: editor
@@ -17,6 +17,7 @@ using TestEnv: TestEnvError, get_test_dir, isinstalled!
 
 export clear_testenv_cache
 
+"Struct containing a ran object, either a testset or a file."
 struct TestInfo
     ex::Expr
     filename::String

--- a/src/TestPicker.jl
+++ b/src/TestPicker.jl
@@ -10,7 +10,6 @@ using Pkg.Types: Context
 using REPL
 using REPL: LineEdit, Terminals
 using Revise: Revise
-using ripgrep_jll: rg
 using Test
 using TestEnv
 using TestEnv: TestEnvError, get_test_dir, isinstalled!

--- a/src/results_viewer.jl
+++ b/src/results_viewer.jl
@@ -18,97 +18,86 @@ It is also possible to inspect the stacktrace as a list with a preview of the so
 `Ctrl+e` edit the source of the current trace.
 """
 function visualize_test_results(repl::AbstractREPL=Base.active_repl)
-    bat() do bat_exe
-        fzf() do fzf_exe
-            editor_cmd = join(editor(), ' ')
-            terminal = repl.t
-            while true
-                dims = get_preview_dimension(terminal)
-                cmd = Cmd(
-                    String[
-                        fzf_exe,
-                        # "fzf",
-                        "--read0",
-                        "--multi",
-                        "--nth",
-                        "1",
-                        "--header",
-                        "Failed and errored tests",
-                        "--with-nth",
-                        "{1}",
-                        "-d",
-                        "$(separator())",
-                        "--preview",
-                        "echo {3} | $(bat_exe) --color=always --style=plain --terminal-width=$(dims.width)",
-                        "--bind",
-                        "ctrl-e:execute($(editor_cmd) {2})",
-                    ],
-                )
-                picked_val = chomp(
-                    read(
-                        pipeline(
-                            Cmd(cmd; ignorestatus=true);
-                            stdin=IOBuffer(read(RESULT_PATH, String)),
-                        ),
-                        String,
-                    ),
-                )
-                # If nothing is picked we exit the loop.
-                isempty(picked_val) && return nothing
+    editor_cmd = join(editor(), ' ')
+    terminal = repl.t
+    while true
+        dims = get_preview_dimension(terminal)
+        bat_preview = "echo {3} | $(get_bat_path()) --color=always --style=plain --terminal-width=$(dims.width)"
+        fzf_args = [
+            "--read0",
+            "--multi",
+            "--nth",
+            "1",
+            "--header",
+            "Failed and errored tests",
+            "--with-nth",
+            "{1}",
+            "-d",
+            "$(separator())",
+            "--preview",
+            bat_preview,
+            "--bind",
+            "ctrl-e:execute($(editor_cmd) {2})",
+        ]
+        cmd = `$(fzf) $(fzf_args)`
+        picked_val = chomp(
+            read(
+                pipeline(
+                    Cmd(cmd; ignorestatus=true); stdin=IOBuffer(read(RESULT_PATH, String))
+                ),
+                String,
+            ),
+        )
+        # If nothing is picked we exit the loop.
+        isempty(picked_val) && return nothing
 
-                # We fetch the data from the picked test.
-                test, _, text = split(picked_val, separator())
+        # We fetch the data from the picked test.
+        test, _, text = split(picked_val, separator())
 
-                # We try to obtain the stack lines.
-                stack_lines = split(text, '\n')
-                start_stack = findfirst(
-                    x -> !isnothing(match(r"^ \[\d+\]", x)), stack_lines
-                )
-                # This happens for fail tests that don't have stacktraces.
-                isnothing(start_stack) && continue
+        # We try to obtain the stack lines.
+        stack_lines = split(text, '\n')
+        start_stack = findfirst(x -> !isnothing(match(r"^ \[\d+\]", x)), stack_lines)
+        # This happens for fail tests that don't have stacktraces.
+        isnothing(start_stack) && continue
 
-                # Some useful dimensions for our preview.
-                dims = get_preview_dimension(terminal)
-                pad = dims.height ÷ 2
-                error = join(vcat(test, stack_lines[1:(start_stack - 2)]), '\n')
-                traces = join.(Iterators.partition(stack_lines[start_stack:end], 2), '\n')
-                enriched = map(traces) do trace
-                    path = match(r"(\S+\.jl):(\d+)", trace)
-                    if !isnothing(path)
-                        file_path, line = remove_ansi.(path.captures)
-                        line_int = Base.parse(Int, line)
-                        line_start = max(0, line_int - pad)
-                        line_end = line_int + pad
-                        source_path = Base.find_source_file(expanduser(file_path))
-                        join([trace, source_path, line, line_start, line_end], separator())
-                    else
-                        trace
-                    end
-                end
-                recut_vals = join(enriched, '\0')
-                cmd = Cmd(
-                    String[
-                        "fzf",
-                        "--multi",
-                        "--read0",
-                        "--ansi",
-                        "--header",
-                        "$(error)",
-                        "--header-label",
-                        "test",
-                        "--with-nth",
-                        "{1}",
-                        "--preview",
-                        "$(bat_exe) --line-range {4}:{5} --highlight-line {3} --color=always --terminal-width=$(dims.width) {2}",
-                        "--bind",
-                        "ctrl-e:execute($(editor_cmd) {2}:{3})",
-                        "-d",
-                        separator(),
-                    ],
-                )
-                run(pipeline(Cmd(cmd; ignorestatus=true); stdin=IOBuffer(recut_vals)))
+        # Some useful dimensions for our preview.
+        dims = get_preview_dimension(terminal)
+        pad = dims.height ÷ 2
+        error = join(vcat(test, stack_lines[1:(start_stack - 2)]), '\n')
+        traces = join.(Iterators.partition(stack_lines[start_stack:end], 2), '\n')
+        enriched = map(traces) do trace
+            path = match(r"(\S+\.jl):(\d+)", trace)
+            if !isnothing(path)
+                file_path, line = remove_ansi.(path.captures)
+                line_int = Base.parse(Int, line)
+                line_start = max(0, line_int - pad)
+                line_end = line_int + pad
+                source_path = Base.find_source_file(expanduser(file_path))
+                join([trace, source_path, line, line_start, line_end], separator())
+            else
+                trace
             end
         end
+        recut_vals = join(enriched, '\0')
+        bat_preview = "$(get_bat_path()) --line-range {4}:{5} --highlight-line {3} --color=always --terminal-width=$(dims.width) {2}"
+        fzf_args = [
+            "--multi", # Show multiple lines
+            "--read0", # Separate lines with \0
+            "--ansi", # Read ANSI characters
+            "--header", # Show header in text
+            "$(error)",
+            "--with-nth",
+            "{1}",
+            "--preview",
+            bat_preview,
+            "--bind",
+            "ctrl-e:execute($(editor_cmd) {2}:{3})",
+            "-d",
+            separator(),
+        ]
+
+        cmd = `$(fzf()) $(fzf_args)`
+        run(pipeline(Cmd(cmd; ignorestatus=true); stdin=IOBuffer(recut_vals)))
     end
 end
 

--- a/src/testblock.jl
+++ b/src/testblock.jl
@@ -127,6 +127,8 @@ function pick_testset(
         "{1}",
         "--preview", # Preview show the relevant testset.
         "$(bat_preview)",
+        "--header",
+        "Selecting testset from filtered test files",
         "--query", # Initial query on the testset names.
         testset_query,
     ]

--- a/src/testfile.jl
+++ b/src/testfile.jl
@@ -65,6 +65,7 @@ function run_test_files(files::AbstractVector{<:AbstractString}, pkg::PackageSpe
     end
 end
 
+"Build and evaluate the expression for the given test file."
 function run_test_file(file::AbstractString, pkg::PackageSpec)
     testset_name = "$(pkg.name) - $(file)"
     ex = quote

--- a/src/testfile.jl
+++ b/src/testfile.jl
@@ -4,13 +4,15 @@ function find_related_testfile(query::AbstractString, pkg::PackageSpec=current_p
     # Run fzf to get a relevant file.
     fzf_args = [
         "-m", # Allow multiple choices.
-        "--preview",
+        "--preview", # Preview the given file with bat.
         "$(get_bat_path()) --color=always --style=numbers {-1}",
-        "--query",
+        "--header",
+        "Selecting test file(s)",
+        "--query", # Initial file query.
         query,
     ]
     cmd = `$(fzf) $(fzf_args)`
-    readlines(
+    files = readlines(
         pipeline(Cmd(cmd; ignorestatus=true, dir=root); stdin=IOBuffer(join(files, '\n')))
     )
     if isempty(files)


### PR DESCRIPTION
- **simplify codebase**
- **fully remove ripgrep**
- **add header for testset**
- **add docstring**
