### PR TITLE
Add file and line number in test preview

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TestPicker"
 uuid = "a64165b9-4409-4de6-85cd-a4e0953bae44"
 authors = ["theogf <theo.galyfajou@gmail.com> and contributors"]
-version = "1.0.3"
+version = "1.0.4"
 
 [deps]
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"

--- a/src/results_viewer.jl
+++ b/src/results_viewer.jl
@@ -29,7 +29,7 @@ function visualize_test_results(
     terminal = repl.t
     while true
         dims = get_preview_dimension(terminal)
-        bat_preview = "echo {3} | $(get_bat_path()) --color=always --style=plain --wrap character --terminal-width=$(dims.width)"
+        bat_preview = "echo -e {3} | $(get_bat_path()) --file-name {2} --language julia --style header,grid --color always --wrap character --strip-ansi always --terminal-width $(dims.width)"
         fzf_args = [
             "--read0",
             "--multi",


### PR DESCRIPTION
Provides a nicer preview of the file name and number:

![image](https://github.com/user-attachments/assets/28e9a5ba-997b-4931-92c6-33cbf0d39454)
