### PR TITLE
Avoid duplicated results in viewer when using `-`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TestPicker"
 uuid = "a64165b9-4409-4de6-85cd-a4e0953bae44"
 authors = ["theogf <theo.galyfajou@gmail.com> and contributors"]
-version = "1.0.4"
+version = "1.0.5"
 
 [deps]
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"

--- a/src/repl.jl
+++ b/src/repl.jl
@@ -132,8 +132,10 @@ function test_mode_do_cmd(repl::AbstractREPL, input::String)
     elseif test_type == TestsetQuery
         fzf_testset(inputs...)
     elseif test_type == LatestEval
+        pkg = current_pkg()
+        clean_results_file(pkg)
         for expr in inputs
-            eval_in_module(expr, current_pkg())
+            eval_in_module(expr, pkg)
         end
     elseif test_type == InspectResults
         visualize_test_results(repl)

--- a/src/results_viewer.jl
+++ b/src/results_viewer.jl
@@ -172,7 +172,6 @@ function save_test_results(
         )
     end
     touch(path)
-    write(path, "")
     open(path, "a+") do io
         iszero(filesize(path)) || write(io, '\0')
         write(io, join(error_content, '\0'))

--- a/src/results_viewer.jl
+++ b/src/results_viewer.jl
@@ -172,6 +172,7 @@ function save_test_results(
         )
     end
     touch(path)
+    write(path, "")
     open(path, "a+") do io
         iszero(filesize(path)) || write(io, '\0')
         write(io, join(error_content, '\0'))


### PR DESCRIPTION
Results were appended instead of replaced when using `-`