### PR TITLE
Allow for alternative test nodes than `@testset`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TestPicker"
 uuid = "a64165b9-4409-4de6-85cd-a4e0953bae44"
 authors = ["theogf <theo.galyfajou@gmail.com> and contributors"]
-version = "1.0.5"
+version = "1.1.0"
 
 [deps]
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ For a best understanding see this small demo:
 
 Run
 
-```
+```julia-repl
 ] add TestPicker
 ```
 
@@ -58,7 +58,7 @@ test> subdirfile
 
 which will get you a fuzzy search, press enter and the file will be run under the test environment.
 
-```julia
+```julia-repl
 [ Info: Executing test file /home/theo/.julia/dev/TestPicker/test/test-subdir/test-file-c.jl
 ```
 
@@ -87,11 +87,27 @@ which will give you e.g. the following selection
 
 Similarly to the multiple files, you can select multiple testsets to be run and they will be run independently.
 
+### Running other test blocks than `@testset`
+
+You have the option to add any macro that follows the `@testset` syntax (e.g. `@testitem` from [`TestItems.jl`](https://github.com/julia-vscode/TestItems.jl)) by adding them to your environment as
+
+```julia
+ENV["TESTPICKER_NODES"] = "@testitem"
+```
+
+You can add mutltiple options, coma-separated.
+
+```julia
+ENV["TESTPICKER_NODES"] = "@testitem, @mycustomtestset"
+```
+
+Note that the environment must be set **before** calling `using TestPicker` is used.
+
 ### Repeating latest test
 
 After running a collection of test files and/or testsets you can just repeat the same operation by calling `-`(in the samme fashion as `cd -`):
 
-```
+```julia-repl
 test> test-a
 [ Info: Executing test file /home/theo/.julia/dev/TestPicker/test/sandbox/test-a.jl
 Test Summary:                                                        | Pass  Total  Time

--- a/src/testset.jl
+++ b/src/testset.jl
@@ -1,7 +1,25 @@
 "Check whether the given `SyntaxNode` is a `@testset` macro block."
-function is_testset(node::SyntaxNode)
+function is_testnode(node::SyntaxNode, testnodes::Vector{Symbol}=testnode_symbols())
     return !isempty(JuliaSyntax.children(node)) &&
-           Expr(first(JuliaSyntax.children(node))) == Symbol("@testset")
+           Expr(first(JuliaSyntax.children(node))) ∈ testnodes
+end
+
+"""
+Fetch all potential test block that can be fetched from the testset parsing.
+Other nodes than `@testset` can be added (coma separated) via `ENV["TESTPICKER_NODES"]`.
+"""
+function testnode_symbols()
+    nodes = [Symbol("@testset")]
+    if haskey(ENV, "TESTPICKER_NODES")
+        str = get(ENV, "TESTPICKER_NODES")
+        names = strip.(split(str, ','))
+        all(startswith("@"), names) ||
+            @warn "The following provided names under `ENV[\"TESTPICKER_NODES\"]` are not macros." filter(
+                !startswith("@"), names
+            )
+        append!(nodes, Symbol.(names))
+    end
+    return nodes
 end
 
 "Check if a statement qualifies as a preamble."
@@ -19,18 +37,26 @@ end
 function get_testsets_with_preambles(file::AbstractString)
     root = parseall(SyntaxNode, read(file, String); filename=file)
     testsets_with_preambles = Vector{Pair{SyntaxNode,Vector{SyntaxNode}}}()
-    get_testsets_with_preambles!(testsets_with_preambles, root)
+    testnodes = testnode_symbols()
+    get_testsets_with_preambles!(testsets_with_preambles, root, testnodes)
     return testsets_with_preambles
 end
 function get_testsets_with_preambles!(
-    testsets_with_preambles, node::SyntaxNode, preamble::Vector{SyntaxNode}=SyntaxNode[]
+    testsets_with_preambles,
+    node::SyntaxNode,
+    testnodes::Vector{Symbol},
+    preamble::Vector{SyntaxNode}=SyntaxNode[],
 )
     for node in JuliaSyntax.children(node)
-        if is_testset(node)
+        if is_testnode(node, testnodes)
             push!(testsets_with_preambles, (node => copy(preamble)))
-            get_testsets_with_preambles!(testsets_with_preambles, node, copy(preamble))
+            get_testsets_with_preambles!(
+                testsets_with_preambles, node, testnodes, copy(preamble)
+            )
         else
-            get_testsets_with_preambles!(testsets_with_preambles, node, copy(preamble))
+            get_testsets_with_preambles!(
+                testsets_with_preambles, node, testnodes, copy(preamble)
+            )
             if is_preamble(node)
                 push!(preamble, node)
             end

--- a/src/testset.jl
+++ b/src/testset.jl
@@ -11,13 +11,13 @@ Other nodes than `@testset` can be added (coma separated) via `ENV["TESTPICKER_N
 function testnode_symbols()
     nodes = [Symbol("@testset")]
     if haskey(ENV, "TESTPICKER_NODES")
-        str = get(ENV, "TESTPICKER_NODES")
+        str = ENV["TESTPICKER_NODES"]
         names = strip.(split(str, ','))
         all(startswith("@"), names) ||
-            @warn "The following provided names under `ENV[\"TESTPICKER_NODES\"]` are not macros." filter(
+            @warn "The following provided names under `ENV[\"TESTPICKER_NODES\"]` are not macros." non_symbols = filter(
                 !startswith("@"), names
             )
-        append!(nodes, Symbol.(names))
+        append!(nodes, Symbol.(filter(startswith("@"), names)))
     end
     return nodes
 end


### PR DESCRIPTION
Fetch alternatives from `ENV["TESTPICKER_NODES"]` to add on top of `@testset`.