### PR TITLE
Use relative path for evaluation

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TestPicker"
 uuid = "a64165b9-4409-4de6-85cd-a4e0953bae44"
 authors = ["theogf <theo.galyfajou@gmail.com> and contributors"]
-version = "1.1.0"
+version = "1.1.1"
 
 [deps]
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"

--- a/src/eval.jl
+++ b/src/eval.jl
@@ -72,6 +72,7 @@ function eval_in_module((; ex, info)::EvalTest, pkg::PackageSpec)
         end
     end
     root = get_test_dir_from_pkg(pkg)
+    # We fetch `dir` such that relative include paths still work as expected.
     dir = dirname(joinpath(root, filename))
     if !isempty(testset)
         @info "Executing testset $(testset) from $(filename):$(line)"
@@ -82,7 +83,6 @@ function eval_in_module((; ex, info)::EvalTest, pkg::PackageSpec)
         # cd acts such that also evaled expressions in `Main` are affected.
         cd(dir) do
             Core.eval(Main, revise_ex)
-            Core.eval(Main, :(println(pwd())))
             Core.eval(Main, top_ex)
         end
     finally

--- a/src/eval.jl
+++ b/src/eval.jl
@@ -71,14 +71,20 @@ function eval_in_module((; ex, info)::EvalTest, pkg::PackageSpec)
             end
         end
     end
+    root = get_test_dir_from_pkg(pkg)
+    dir = dirname(joinpath(root, filename))
     if !isempty(testset)
         @info "Executing testset $(testset) from $(filename):$(line)"
     else
         @info "Executing test file $(filename)"
     end
     try
-        Core.eval(Main, revise_ex)
-        Core.eval(Main, top_ex)
+        # cd acts such that also evaled expressions in `Main` are affected.
+        cd(dir) do
+            Core.eval(Main, revise_ex)
+            Core.eval(Main, :(println(pwd())))
+            Core.eval(Main, top_ex)
+        end
     finally
         Core.eval(Main, env_return)
         Core.eval(Main, clean_module)

--- a/src/testset.jl
+++ b/src/testset.jl
@@ -154,7 +154,9 @@ function pick_testset(
     return readlines(pipeline(cmd; stdin=IOBuffer(join(keys(tabled_keys), '\n'))))
 end
 
-function build_testset_list(choices, full_map, tabled_keys, pkg::PackageSpec)
+function build_testset_list(
+    choices, full_map, tabled_keys, root::AbstractString, pkg::PackageSpec
+)
     map(choices) do choice
         testset_info = tabled_keys[choice]
         testset, preamble = full_map[testset_info]
@@ -168,7 +170,13 @@ function build_testset_list(choices, full_map, tabled_keys, pkg::PackageSpec)
                 TestPicker.save_test_results(e, $(test_info), $(pkg))
             end
         end
-        ex = Expr(:block, Expr.(preamble)..., tried_testset)
+        ex = quote
+            cd($(dirname(joinpath(root, file_name)))) do
+                $(Expr.(preamble)...)
+                $(tried_testset)
+            end
+        end
+        # ex = Expr(:block, Expr.(preamble)..., tried_testset)
         EvalTest(ex, test_info)
     end
 end
@@ -184,7 +192,7 @@ function fzf_testset(fuzzy_file::AbstractString, fuzzy_testset::AbstractString)
 
     choices = pick_testset(tabled_keys, fuzzy_testset, root)
     if !isempty(choices)
-        tests = build_testset_list(choices, full_map, tabled_keys, pkg)
+        tests = build_testset_list(choices, full_map, tabled_keys, root, pkg)
         clean_results_file(pkg)
         LATEST_EVAL[] = tests
         for test in tests


### PR DESCRIPTION
Fixes #48 

`cd` into the parent directory of the test file to ensure `include` work as expected.