### PR TITLE
Add `replace_interface!`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TestPicker"
 uuid = "a64165b9-4409-4de6-85cd-a4e0953bae44"
 authors = ["theogf <theo.galyfajou@gmail.com> and contributors"]
-version = "1.2.1"
+version = "1.3.0"
 
 [deps]
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"

--- a/src/TestPicker.jl
+++ b/src/TestPicker.jl
@@ -16,7 +16,7 @@ using TestEnv
 using TestEnv: TestEnvError, get_test_dir, isinstalled!
 
 export clear_testenv_cache
-export TestBlockInterface, add_interface!
+export TestBlockInterface, add_interface!, replace_interface!
 
 """
     TestInfo
@@ -143,15 +143,15 @@ add_interface!(MyTestInterface())
 
 # Now TestPicker will recognize your test blocks
 ```
-
-# Side Effects
-Modifies the global [`INTERFACES`](@ref) collection, affecting all subsequent
-test parsing and execution operations.
-
-# See also
-[`INTERFACES`](@ref), [`TestBlockInterface`](@ref)
 """
 add_interface!(interface::TestBlockInterface) = unique!(push!(INTERFACES, interface))
+
+"""
+    replace_interface!(interface::TestBlockInterface) -> Vector{TestBlockInterface}
+
+Similar to `add_interface!` but empty the interface first before adding the new one so that it becomes the unique interface.
+"""
+replace_interface!(interface::TestBlockInterface) = push!(empty!(INTERFACES), interface)
 
 function __init__()
     # Add the REPL mode to the current active REPL.

--- a/src/TestPicker.jl
+++ b/src/TestPicker.jl
@@ -30,9 +30,6 @@ used for tracking test execution and displaying results.
 - `filename::String`: Source file containing the test
 - `label::String`: Human-readable test identifier (e.g., testset name)
 - `line::Int`: Line number where the test begins
-
-# See also
-[`EvalTest`](@ref), [`save_test_results`](@ref)
 """
 struct TestInfo
     filename::String
@@ -55,9 +52,6 @@ and context. Used throughout TestPicker for tracking and executing tests.
 # Usage
 `EvalTest` objects are created during test parsing and stored in [`LATEST_EVAL`](@ref)
 for re-execution and result tracking.
-
-# See also
-[`TestInfo`](@ref), [`eval_in_module`](@ref), [`LATEST_EVAL`](@ref)
 """
 struct EvalTest
     ex::Expr
@@ -120,9 +114,6 @@ Use [`add_interface!`](@ref) to register additional test block interfaces:
 # Add support for custom test blocks
 add_interface!(MyCustomTestInterface())
 ```
-
-# See also
-[`TestBlockInterface`](@ref), [`StdTestset`](@ref), [`add_interface!`](@ref)
 """
 const INTERFACES = TestBlockInterface[StdTestset()]
 

--- a/src/eval.jl
+++ b/src/eval.jl
@@ -80,9 +80,6 @@ test = EvalTest(:(using Test; @test 1+1 == 2), TestInfo("test.jl", "arithmetic",
 pkg = PackageSpec(name="MyPackage", path="/path/to/package")
 eval_in_module(test, pkg)
 ```
-
-# See also
-[`EvalTest`](@ref), [`TESTENV_CACHE`](@ref), [`prepend_ex`](@ref), [`clear_testenv_cache`](@ref)
 """
 function eval_in_module((; ex, info)::EvalTest, pkg::PackageSpec)
     (; filename, label, line) = info
@@ -145,6 +142,7 @@ function eval_in_module((; ex, info)::EvalTest, pkg::PackageSpec)
     else
         @info "Executing test file $(filename)"
     end
+    @debug "Evaluating code block" top_ex
     try
         # cd acts such that also evaled expressions in `Main` are affected.
         cd(dir) do

--- a/src/repl.jl
+++ b/src/repl.jl
@@ -27,9 +27,6 @@ The test mode supports:
 - Standard REPL features (history, search, etc.)
 - Custom test commands and query parsing
 - Seamless switching between main and test modes
-
-# See also
-[`create_repl_test_mode`](@ref)
 """
 function init_test_repl_mode(repl::AbstractREPL)
     # Get the main REPL mode (julia prompt).
@@ -85,9 +82,6 @@ support, key bindings, and command processing.
 - Integrated history and search functionality
 - Error handling for test execution failures
 - Automatic return to main mode when appropriate
-
-# See also
-[`init_test_repl_mode`](@ref), [`test_mode_do_cmd`](@ref)
 """
 function create_repl_test_mode(repl::AbstractREPL, main::LineEdit.Prompt)
     test_mode = LineEdit.Prompt(
@@ -189,9 +183,6 @@ identify_query("?")                      # (InspectResults, ())
 # Error Handling
 - Returns `UnmatchedQuery` for inputs that cannot be parsed
 - Handles case where no previous evaluation exists for "-" command
-
-# See also
-[`QueryType`](@ref), [`test_mode_do_cmd`](@ref)
 """
 function identify_query(input::AbstractString)
     if strip(input) == "-"
@@ -250,9 +241,6 @@ and dispatches to the appropriate test execution or inspection function.
 # "-"                 # Re-run last tests
 # "?"                 # View test results
 ```
-
-# See also
-[`identify_query`](@ref), [`fzf_testfile`](@ref), [`fzf_testblock`](@ref), [`visualize_test_results`](@ref)
 """
 function test_mode_do_cmd(repl::AbstractREPL, input::String)
     if !isinteractive() && get(ENV, "PRINT_REPL_WARNING", true)

--- a/src/results_viewer.jl
+++ b/src/results_viewer.jl
@@ -58,9 +58,6 @@ visualize_test_results()
 pkg = PackageSpec(name="MyPackage")
 visualize_test_results(Base.active_repl, pkg)
 ```
-
-# See also
-[`save_test_results`](@ref), [`get_preview_dimension`](@ref), [`separator`](@ref)
 """
 function visualize_test_results(
     repl::AbstractREPL=Base.active_repl, pkg::PackageSpec=current_pkg()

--- a/src/testblockinterface.jl
+++ b/src/testblockinterface.jl
@@ -36,9 +36,6 @@ function blocklabel(::NoWarnTestInterface, node::SyntaxNode)
     return "nowarn: " * JuliaSyntax.sourcetext(JuliaSyntax.children(node)[2])
 end
 ```
-
-# See also
-[`StdTestset`](@ref), [`istestblock`](@ref), [`blocklabel`](@ref)
 """
 abstract type TestBlockInterface end
 
@@ -99,9 +96,6 @@ function blocklabel(::StdTestset, node::SyntaxNode)
     return JuliaSyntax.sourcetext(JuliaSyntax.children(node)[2])
 end
 ```
-
-# See also  
-[`TestBlockInterface`](@ref), [`istestblock`](@ref)
 """
 function blocklabel(::T, node::SyntaxNode) where {T<:TestBlockInterface}
     return error("`blocklabel` must be implemented for type $(T).")
@@ -140,9 +134,6 @@ function preamble(::MyCustomInterface)
     end
 end
 ```
-
-# See also
-[`TestBlockInterface`](@ref), [`prepend_preamble_statements`](@ref)
 """
 function preamble(::TestBlockInterface)
     return nothing
@@ -171,9 +162,6 @@ existing = [:(x = 1), :(y = 2)]
 result = prepend_preamble_statements(interface, existing)
 # Returns: [:(using Test), :(x = 1), :(y = 2)]
 ```
-
-# See also
-[`preamble`](@ref), [`TestBlockInterface`](@ref)
 """
 function prepend_preamble_statements(interface::TestBlockInterface, preambles::Vector{Expr})
     interface_preamble = preamble(interface)
@@ -228,9 +216,6 @@ function expr_transform(::SafeTestInterface, ex::Expr)
     end
 end
 ```
-
-# See also
-[`TestBlockInterface`](@ref), [`preamble`](@ref)
 """
 function expr_transform(::TestBlockInterface, ex::Expr)
     return ex
@@ -261,9 +246,6 @@ end
 
 # The label would be: "Basic arithmetic tests"
 ```
-
-# See also
-[`TestBlockInterface`](@ref), [`istestblock`](@ref), [`blocklabel`](@ref), [`preamble`](@ref)
 """
 struct StdTestset <: TestBlockInterface end
 

--- a/src/testfile.jl
+++ b/src/testfile.jl
@@ -28,9 +28,6 @@ files = select_test_files("math")
 pkg = PackageSpec(name="MyPackage")
 files = select_test_files("integration", pkg)
 ```
-
-# See also
-[`get_test_files`](@ref), [`fzf_testfile`](@ref)
 """
 function select_test_files(query::AbstractString, pkg::PackageSpec=current_pkg())
     root, files = get_test_files(pkg)
@@ -132,9 +129,6 @@ fzf_testfile("integration")
 # Run all test files (empty query shows all)
 fzf_testfile("")
 ```
-
-# See also
-[`select_test_files`](@ref), [`run_test_files`](@ref)
 """
 function fzf_testfile(query::AbstractString)
     pkg = current_pkg()
@@ -170,9 +164,6 @@ the test evaluation state. Each file is wrapped in a testset and executed in iso
 - Validates file paths before execution
 - Reports missing files as errors with bug report guidance
 - Individual file failures don't stop batch execution
-
-# See also
-[`run_test_file`](@ref), [`select_test_files`](@ref), [`clean_results_file`](@ref)
 """
 function run_test_files(files::AbstractVector{<:AbstractString}, pkg::PackageSpec)
     # We return early to not empty the LATEST_EVAL
@@ -226,9 +217,6 @@ end
 - Test failures are caught and saved rather than propagated
 - Non-test errors are re-thrown
 - File-level errors are properly contextualized
-
-# See also
-[`eval_in_module`](@ref), [`save_test_results`](@ref), [`EvalTest`](@ref)
 """
 function run_test_file(file::AbstractString, pkg::PackageSpec)
     testset_name = "$(pkg.name) - $(file)"


### PR DESCRIPTION
Add other convenience function to automatically remove the default list of interfaces