### PR TITLE
Refresh rerun expressions when the test file changed

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ version = "2.6.0"
 
 
 [deps]
+CRC32c = "8bf52ea8-c179-5cab-976a-9e18b702a9bc"
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 JuliaSyntax = "70703baa-626e-46a2-a12c-08ffd08c73b4"
 Markdown = "d6f4376e-aef5-505a-96c1-9c027394607a"
@@ -18,6 +19,7 @@ bat_jll = "e1736374-6498-5d90-ab12-e7e58ba27d07"
 fzf_jll = "214eeab7-80f7-51ab-84ad-2988db7cef09"
 
 [compat]
+CRC32c = "1"
 InteractiveUtils = "1"
 JuliaSyntax = "0.4, 1"
 Markdown = "1"

--- a/src/TestPicker.jl
+++ b/src/TestPicker.jl
@@ -43,11 +43,19 @@ Container for executable test code and its associated metadata.
 
 Combines a Julia expression representing test code with metadata about its source
 and context. Used throughout TestPicker for tracking and executing tests.
+
+For test blocks, `filehash` stores a hash of the source file content at the time
+the expression was built, so that reruns can detect a modified file and rebuild
+the expression (see [`refresh_evaltest`](@ref)). A value of `nothing` means the
+expression reads its source afresh on every run (e.g. whole-file runs based on
+`include`) and can never go stale.
 """
 struct EvalTest
     ex::Expr
     info::TestInfo
+    filehash::Union{Nothing,UInt64}
 end
+EvalTest(ex::Expr, info::TestInfo) = EvalTest(ex, info, nothing)
 
 """
     EvalResult{T}

--- a/src/TestPicker.jl
+++ b/src/TestPicker.jl
@@ -1,6 +1,7 @@
 module TestPicker
 
 using bat_jll: get_bat_path
+using CRC32c: crc32c
 using fzf_jll: fzf
 using JuliaSyntax
 using JuliaSyntax: @K_str, sourcetext

--- a/src/docs.jl
+++ b/src/docs.jl
@@ -13,7 +13,7 @@ const HELP_TEXT = Markdown.md"""
   - Select testset(s) in fzf and press Enter to run
 
 ## Special Commands
-- `test> -` → Re-run the last test evaluation
+- `test> -` → Re-run the last test evaluation (picks up edits made to the test files)
 - `test> @` → Inspect test results (errors/failures)
   - Press Enter to view stacktrace
   - Press Ctrl+e to edit test file

--- a/src/repl.jl
+++ b/src/repl.jl
@@ -217,8 +217,11 @@ function test_mode_do_cmd(repl::AbstractREPL, input::String)
     elseif test_type == LatestEval
         pkg = current_pkg()
         clean_results_file(pkg)
-        for expr in inputs
-            eval_in_module(expr, pkg)
+        # Rebuild tests whose source file changed since they were picked.
+        tests = map(test -> refresh_evaltest(INTERFACES, test, pkg), inputs)
+        LATEST_EVAL[] = tests
+        for test in tests
+            eval_in_module(test, pkg)
         end
     elseif test_type == TestModeDocs
         print_test_docs()

--- a/src/testblock.jl
+++ b/src/testblock.jl
@@ -211,13 +211,53 @@ function pick_testblock(
 end
 
 """
+    hash_file(path::AbstractString) -> UInt64
+
+Hash the content of a file, used to detect that a test file was modified between
+the moment a test block was picked and the moment it is rerun.
+"""
+hash_file(path::AbstractString) = hash(read(path))
+
+"""
+    build_evaltest(blockinfo::TestBlockInfo, syntax_block::SyntaxBlock, pkg::PackageSpec) -> EvalTest
+
+Build an executable [`EvalTest`](@ref) from a parsed test block.
+
+The test block is wrapped in a try-catch block to handle test failures gracefully and
+save results, and its preamble statements are prepended. The current content hash of the
+source file is recorded so that reruns can detect a stale expression.
+"""
+function build_evaltest(
+    blockinfo::TestBlockInfo, syntax_block::SyntaxBlock, pkg::PackageSpec
+)
+    (; label, file_name, line_start) = blockinfo
+    test_info = TestInfo(file_name, label, line_start)
+    (; preamble, testblock, interface) = syntax_block
+    root = get_test_dir_from_pkg(pkg)
+    block_expr = expr_transform(interface, Expr(testblock), blockinfo, root)
+    tried_testset = quote
+        try
+            @testset TestPickerTestSet $(label) begin
+                $(block_expr)
+            end
+        catch e
+            !(e isa Union{TestSetException,TestPicker.TestPickerTestSetException}) &&
+                rethrow()
+            TestPicker.save_test_results(e, $(test_info), $(pkg))
+        end
+    end
+    preamble_statements = prepend_preamble_statements(interface, Expr.(preamble))
+    ex = Expr(:block, preamble_statements..., tried_testset)
+    return EvalTest(ex, test_info, hash_file(joinpath(root, file_name)))
+end
+
+"""
     testblock_list(choices, info_to_syntax, display_to_info, pkg) -> Vector{EvalTest}
 
 Convert user-selected test block choices into executable test objects.
 
 Takes the selected display strings from fzf and converts them into `EvalTest` objects
-that can be evaluated. Each test is wrapped in a try-catch block to handle test failures
-gracefully and save results.
+that can be evaluated (see [`build_evaltest`](@ref)).
 """
 function testblock_list(
     choices::Vector{<:AbstractString},
@@ -228,26 +268,52 @@ function testblock_list(
     map(choices) do choice
         blockinfo = display_to_info[choice]
         syntax_block = info_to_syntax[blockinfo]
-        (; label, file_name, line_start) = blockinfo
-        test_info = TestInfo(file_name, label, line_start)
-        (; preamble, testblock, interface) = syntax_block
-        block_expr = expr_transform(
-            interface, Expr(testblock), blockinfo, get_test_dir_from_pkg(pkg)
-        )
-        tried_testset = quote
-            try
-                @testset TestPickerTestSet $(label) begin
-                    $(block_expr)
-                end
-            catch e
-                !(e isa Union{TestSetException,TestPicker.TestPickerTestSetException}) && rethrow()
-                TestPicker.save_test_results(e, $(test_info), $(pkg))
-            end
-        end
-        preamble_statements = prepend_preamble_statements(interface, Expr.(preamble))
-        ex = Expr(:block, preamble_statements..., tried_testset)
-        EvalTest(ex, test_info)
+        build_evaltest(blockinfo, syntax_block, pkg)
     end
+end
+
+"""
+    refresh_evaltest(interfaces, test::EvalTest, pkg::PackageSpec) -> EvalTest
+
+Return an up-to-date version of `test`, rebuilding its expression if the source file changed.
+
+Rerunning a test block evaluates a previously built expression, which would silently ignore
+any edit made to the test file in the meantime. This function detects such edits by comparing
+the stored file hash with the current one. If the file changed, it is re-parsed and the test
+block with the same label is looked up again (when several blocks share the label, the one
+closest to the original line wins) and rebuilt, picking up both the new block content and any
+modified preamble.
+
+The original `test` is returned unchanged when it does not track a source file
+(`filehash === nothing`, e.g. whole-file runs that `include` the file afresh), when the file
+content is identical, or — with a warning — when the file or the block cannot be found anymore.
+"""
+function refresh_evaltest(
+    interfaces::Vector{<:TestBlockInterface}, test::EvalTest, pkg::PackageSpec
+)
+    isnothing(test.filehash) && return test
+    (; filename, label, line) = test.info
+    root = get_test_dir_from_pkg(pkg)
+    path = joinpath(root, filename)
+    if !isfile(path)
+        @warn "Test file $(filename) does not exist anymore, rerunning the previously evaluated version of $(label)."
+        return test
+    end
+    hash_file(path) == test.filehash && return test
+    matches = [
+        (TestBlockInfo(syntax_block, filename), syntax_block) for
+        syntax_block in get_syntax_blocks(interfaces, path)
+    ]
+    filter!(((blockinfo, _),) -> blockinfo.label == label, matches)
+    if isempty(matches)
+        @warn "Could not find test block $(label) in the modified file $(filename), rerunning the previously evaluated version."
+        return test
+    end
+    blockinfo, syntax_block = argmin(
+        ((blockinfo, _),) -> abs(blockinfo.line_start - line), matches
+    )
+    @info "$(filename) was modified, rerunning the updated version of test block $(label)."
+    return build_evaltest(blockinfo, syntax_block, pkg)
 end
 
 """

--- a/src/testblock.jl
+++ b/src/testblock.jl
@@ -215,8 +215,12 @@ end
 
 Hash the content of a file, used to detect that a test file was modified between
 the moment a test block was picked and the moment it is rerun.
+
+Uses the hardware-accelerated CRC32c checksum from the standard library, streaming
+the file instead of reading it into memory. Collision resistance is irrelevant here:
+the hash only guards against missing an accidental edit of a test file.
 """
-hash_file(path::AbstractString) = hash(read(path))
+hash_file(path::AbstractString) = UInt64(open(crc32c, path))
 
 """
     build_evaltest(blockinfo::TestBlockInfo, syntax_block::SyntaxBlock, pkg::PackageSpec) -> EvalTest

--- a/test/testblock.jl
+++ b/test/testblock.jl
@@ -1,7 +1,8 @@
 using Test
 using JuliaSyntax
+using Pkg: PackageSpec
 using TestPicker
-using TestPicker: TestBlockInfo, StdTestset, SyntaxBlock, EvalResult
+using TestPicker: TestBlockInfo, StdTestset, SyntaxBlock, EvalResult, EvalTest, TestInfo
 using TestPicker:
     get_syntax_blocks,
     get_testfiles,
@@ -9,7 +10,11 @@ using TestPicker:
     build_info_to_syntax,
     pick_testblock,
     istestblock,
-    fzf_testblock
+    fzf_testblock,
+    testblock_list,
+    refresh_evaltest,
+    hash_file,
+    get_test_dir_from_pkg
 
 function no_indentation(s::AbstractString)
     return replace(s, r"^\s+"m => "")
@@ -150,4 +155,89 @@ end
     result = fzf_testblock(interfaces, "test-a", "testset"; interactive=false)
     @test result isa Vector
     @test all(r -> r isa EvalResult, result)
+end
+
+@testset "Refresh eval test when file was modified" begin
+    pkg = PackageSpec(; name="TestPicker", path=pkgdir(TestPicker))
+    root = get_test_dir_from_pkg(pkg)
+    interfaces = [StdTestset()]
+    filename = joinpath("sandbox", "tmp-refresh.jl")
+    path = joinpath(root, filename)
+    try
+        write(
+            path,
+            """
+            using Test
+            x = 1
+            @testset "refresh me" begin
+                @test x == 1
+            end
+            """,
+        )
+        full_map, tabled_keys = build_info_to_syntax(interfaces, root, [filename])
+        test = only(testblock_list(collect(keys(tabled_keys)), full_map, tabled_keys, pkg))
+        @test test.info.line == 3
+        @test test.filehash == hash_file(path)
+
+        # Unchanged file: the exact same test is returned.
+        @test refresh_evaltest(interfaces, test, pkg) === test
+
+        # Tests without a tracked file (e.g. whole-file runs) are returned as-is.
+        file_test = EvalTest(:(include($path)), TestInfo(filename, "", 0))
+        @test refresh_evaltest(interfaces, file_test, pkg) === file_test
+
+        # Modified file: the block is looked up again and the expression rebuilt.
+        write(
+            path,
+            """
+            using Test
+            x = 2
+
+            @testset "refresh me" begin
+                @test x == 2
+            end
+            """,
+        )
+        refreshed = @test_logs (:info,) refresh_evaltest(interfaces, test, pkg)
+        @test refreshed.info.line == 4
+        @test refreshed.filehash == hash_file(path)
+        @test refreshed.filehash != test.filehash
+        @test occursin("x == 2", string(refreshed.ex))
+        # The refreshed preamble is picked up as well.
+        @test occursin("x = 2", string(refreshed.ex))
+
+        # Duplicated labels: the block closest to the original line wins.
+        write(
+            path,
+            """
+            using Test
+            @testset "refresh me" begin
+                @test true
+            end
+            @testset "refresh me" begin
+                @test true
+            end
+            """,
+        )
+        refreshed = @test_logs (:info,) refresh_evaltest(interfaces, test, pkg)
+        @test refreshed.info.line == 2
+
+        # Renamed block: fall back to the previously evaluated version with a warning.
+        write(
+            path,
+            """
+            using Test
+            @testset "renamed" begin
+                @test true
+            end
+            """,
+        )
+        @test (@test_logs (:warn,) refresh_evaltest(interfaces, test, pkg)) === test
+
+        # Deleted file: fall back to the previously evaluated version with a warning.
+        rm(path)
+        @test (@test_logs (:warn,) refresh_evaltest(interfaces, test, pkg)) === test
+    finally
+        isfile(path) && rm(path)
+    end
 end


### PR DESCRIPTION
## Summary

The rerun command (`test> -`) re-evaluates the exact expression that was built when a test block was picked. If the test file was edited in the meantime, the rerun silently executed the stale code. This PR makes reruns pick up file changes:

- `EvalTest` now stores a content hash of its source file (`nothing` for whole-file runs, which `include` the file afresh and can never go stale; a 2-arg constructor keeps the old call sites working).
- On `test> -`, a new `refresh_evaltest` compares hashes. If the file changed, it is re-parsed and the block with the same label is located again (on duplicate labels, the block closest to the original line wins) and rebuilt via the same code path as a fresh pick — so edited preamble statements are refreshed too.
- If the block or the file no longer exists, the previously evaluated version is rerun with a warning.
- `LATEST_EVAL` is updated with the refreshed tests so consecutive reruns compare against the latest file state.

A content hash is used instead of `mtime` so touch-style events or git checkouts restoring identical content don't trigger a rebuild.

## Test plan

- New testset "Refresh eval test when file was modified" covering: unchanged file returns the identical test, untracked (whole-file) tests pass through, modified file rebuilds expression/line/hash including the preamble, duplicate-label disambiguation, and renamed-block / deleted-file fallbacks.
- Full test suite passes locally on Julia 1.12.

🤖 Generated with [Claude Code](https://claude.com/claude-code)