### PR TITLE
Testblock: check for file hash and perform naive search

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TestPicker"
 uuid = "a64165b9-4409-4de6-85cd-a4e0953bae44"
 authors = ["theogf <theo.galyfajou@gmail.com> and contributors"]
-version = "2.6.0"
+version = "2.7.0"
 
 
 [deps]

--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ version = "2.6.0"
 
 
 [deps]
+CRC32c = "8bf52ea8-c179-5cab-976a-9e18b702a9bc"
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 JuliaSyntax = "70703baa-626e-46a2-a12c-08ffd08c73b4"
 Markdown = "d6f4376e-aef5-505a-96c1-9c027394607a"
@@ -18,6 +19,7 @@ bat_jll = "e1736374-6498-5d90-ab12-e7e58ba27d07"
 fzf_jll = "214eeab7-80f7-51ab-84ad-2988db7cef09"
 
 [compat]
+CRC32c = "1"
 InteractiveUtils = "1"
 JuliaSyntax = "0.4, 1"
 Markdown = "1"

--- a/src/TestPicker.jl
+++ b/src/TestPicker.jl
@@ -43,11 +43,19 @@ Container for executable test code and its associated metadata.
 
 Combines a Julia expression representing test code with metadata about its source
 and context. Used throughout TestPicker for tracking and executing tests.
+
+`mtime` records the modification time of the source file when `ex` was captured, so
+that a rerun (`test> -`) can detect that the file changed in the meantime and try to
+relocate the block instead of blindly replaying a stale expression; see
+[`refresh_stale_test`](@ref).
 """
 struct EvalTest
     ex::Expr
     info::TestInfo
+    mtime::Float64
 end
+
+EvalTest(ex::Expr, info::TestInfo) = EvalTest(ex, info, 0.0)
 
 """
     EvalResult{T}

--- a/src/TestPicker.jl
+++ b/src/TestPicker.jl
@@ -1,5 +1,6 @@
 module TestPicker
 
+using CRC32c: crc32c
 using bat_jll: get_bat_path
 using fzf_jll: fzf
 using JuliaSyntax
@@ -44,18 +45,20 @@ Container for executable test code and its associated metadata.
 Combines a Julia expression representing test code with metadata about its source
 and context. Used throughout TestPicker for tracking and executing tests.
 
-`mtime` records the modification time of the source file when `ex` was captured, so
-that a rerun (`test> -`) can detect that the file changed in the meantime and try to
-relocate the block instead of blindly replaying a stale expression; see
+`content_hash` is the CRC32c checksum of the source file's contents when `ex` was
+captured, so that a rerun (`test> -`) can detect that the file changed in the meantime
+(a content hash catches edits that a modification time can miss, e.g. on filesystems
+with coarse mtime resolution, or a save that happens to restore the original mtime) and
+try to relocate the block instead of blindly replaying a stale expression; see
 [`refresh_stale_test`](@ref).
 """
 struct EvalTest
     ex::Expr
     info::TestInfo
-    mtime::Float64
+    content_hash::UInt32
 end
 
-EvalTest(ex::Expr, info::TestInfo) = EvalTest(ex, info, 0.0)
+EvalTest(ex::Expr, info::TestInfo) = EvalTest(ex, info, 0x00000000)
 
 """
     EvalResult{T}

--- a/src/repl.jl
+++ b/src/repl.jl
@@ -217,8 +217,10 @@ function test_mode_do_cmd(repl::AbstractREPL, input::String)
     elseif test_type == LatestEval
         pkg = current_pkg()
         clean_results_file(pkg)
-        for expr in inputs
-            eval_in_module(expr, pkg)
+        refreshed = filter(!isnothing, refresh_stale_test.(inputs, Ref(pkg)))
+        LATEST_EVAL[] = refreshed
+        for test in refreshed
+            eval_in_module(test, pkg)
         end
     elseif test_type == TestModeDocs
         print_test_docs()

--- a/src/testblock.jl
+++ b/src/testblock.jl
@@ -211,6 +211,38 @@ function pick_testblock(
 end
 
 """
+    build_eval_test(blockinfo::TestBlockInfo, syntax_block::SyntaxBlock, pkg::PackageSpec) -> EvalTest
+
+Build an executable [`EvalTest`](@ref) from a located test block.
+
+Wraps the block in a `TestPickerTestSet`, prepends any preamble required by its
+interface, and records the source file's current modification time (used by
+[`refresh_stale_test`](@ref) to detect edits before a rerun).
+"""
+function build_eval_test(
+    blockinfo::TestBlockInfo, syntax_block::SyntaxBlock, pkg::PackageSpec
+)::EvalTest
+    (; label, file_name, line_start) = blockinfo
+    test_info = TestInfo(file_name, label, line_start)
+    (; preamble, testblock, interface) = syntax_block
+    root = get_test_dir_from_pkg(pkg)
+    block_expr = expr_transform(interface, Expr(testblock), blockinfo, root)
+    tried_testset = quote
+        try
+            @testset TestPickerTestSet $(label) begin
+                $(block_expr)
+            end
+        catch e
+            !(e isa Union{TestSetException,TestPicker.TestPickerTestSetException}) && rethrow()
+            TestPicker.save_test_results(e, $(test_info), $(pkg))
+        end
+    end
+    preamble_statements = prepend_preamble_statements(interface, Expr.(preamble))
+    ex = Expr(:block, preamble_statements..., tried_testset)
+    return EvalTest(ex, test_info, mtime(joinpath(root, file_name)))
+end
+
+"""
     testblock_list(choices, info_to_syntax, display_to_info, pkg) -> Vector{EvalTest}
 
 Convert user-selected test block choices into executable test objects.
@@ -228,25 +260,7 @@ function testblock_list(
     map(choices) do choice
         blockinfo = display_to_info[choice]
         syntax_block = info_to_syntax[blockinfo]
-        (; label, file_name, line_start) = blockinfo
-        test_info = TestInfo(file_name, label, line_start)
-        (; preamble, testblock, interface) = syntax_block
-        block_expr = expr_transform(
-            interface, Expr(testblock), blockinfo, get_test_dir_from_pkg(pkg)
-        )
-        tried_testset = quote
-            try
-                @testset TestPickerTestSet $(label) begin
-                    $(block_expr)
-                end
-            catch e
-                !(e isa Union{TestSetException,TestPicker.TestPickerTestSetException}) && rethrow()
-                TestPicker.save_test_results(e, $(test_info), $(pkg))
-            end
-        end
-        preamble_statements = prepend_preamble_statements(interface, Expr.(preamble))
-        ex = Expr(:block, preamble_statements..., tried_testset)
-        EvalTest(ex, test_info)
+        build_eval_test(blockinfo, syntax_block, pkg)
     end
 end
 

--- a/src/testblock.jl
+++ b/src/testblock.jl
@@ -62,7 +62,7 @@ to determine what constitutes a test block.
 - `Vector{SyntaxBlock}`: Collection of parsed test blocks with their preambles
 """
 function get_syntax_blocks(interfaces::Vector{<:TestBlockInterface}, file::AbstractString)
-    root = parseall(SyntaxNode, read(file, String); filename=file)
+    root = parseall(SyntaxNode, read(file, String); filename = file)
     return mapreduce(vcat, interfaces) do interface
         syntax_blocks = Vector{SyntaxBlock}()
         get_syntax_blocks!(interface, syntax_blocks, root)
@@ -73,7 +73,7 @@ function get_syntax_blocks!(
     interface::TestBlockInterface,
     syntax_blocks::Vector{SyntaxBlock},
     node::SyntaxNode,
-    preamble::Vector{SyntaxNode}=SyntaxNode[],
+    preamble::Vector{SyntaxNode} = SyntaxNode[],
 )
     nodes = JuliaSyntax.children(node)
     isnothing(nodes) && return nothing
@@ -112,12 +112,13 @@ get_matching_files("math", files)  # Returns ["test/test_math.jl"]
 ```
 """
 function get_matching_files(
-    file_query::AbstractString, test_files::AbstractVector{<:AbstractString}
+    file_query::AbstractString,
+    test_files::AbstractVector{<:AbstractString},
 )
     return readlines(
         pipeline(
-            Cmd(`$(fzf()) --filter $(file_query)`; ignorestatus=true);
-            stdin=IOBuffer(join(test_files, '\n')),
+            Cmd(`$(fzf()) --filter $(file_query)`; ignorestatus = true);
+            stdin = IOBuffer(join(test_files, '\n')),
         ),
     )
 end
@@ -147,6 +148,8 @@ function build_info_to_syntax(
             end,
         )
     end
+    # None of the matched files contained any recognized test block.
+    isempty(info_to_syntax) && return info_to_syntax, Dict{String,TestBlockInfo}()
     # We estimate the max length to perform some padding.
     max_label_length = maximum(length ∘ label, keys(info_to_syntax))
     max_filename_length = maximum(length ∘ file_name, keys(info_to_syntax))
@@ -175,16 +178,17 @@ function pick_testblock(
     tabled_keys::Dict{String,TestBlockInfo},
     testset_query::AbstractString,
     root::AbstractString;
-    interactive::Bool=true,
+    interactive::Bool = true,
 )
     args = ["--filter", testset_query, "-d", "$(separator())", "--nth", "1"]
-    cmd = Cmd(`$(fzf()) $(args)`; ignorestatus=true, dir=root)
+    cmd = Cmd(`$(fzf()) $(args)`; ignorestatus = true, dir = root)
     # We do a dry lookup to see what results we get.
-    filtered_list = readlines(pipeline(cmd; stdin=IOBuffer(join(keys(tabled_keys), '\n'))))
+    filtered_list =
+        readlines(pipeline(cmd; stdin = IOBuffer(join(keys(tabled_keys), '\n'))))
     if !interactive || isone(length(filtered_list))
         # Non-interactive mode: use fzf --filter to get matching test blocks
         args = ["--filter", testset_query, "-d", "$(separator())", "--nth", "1"]
-        cmd = Cmd(`$(fzf()) $(args)`; ignorestatus=true, dir=root)
+        cmd = Cmd(`$(fzf()) $(args)`; ignorestatus = true, dir = root)
         return filtered_list
     end
 
@@ -206,8 +210,8 @@ function pick_testblock(
         "--query", # Initial query on the testset names.
         testset_query,
     ]
-    cmd = Cmd(`$(fzf()) $(args)`; ignorestatus=true, dir=root)
-    return readlines(pipeline(cmd; stdin=IOBuffer(join(keys(tabled_keys), '\n'))))
+    cmd = Cmd(`$(fzf()) $(args)`; ignorestatus = true, dir = root)
+    return readlines(pipeline(cmd; stdin = IOBuffer(join(keys(tabled_keys), '\n'))))
 end
 
 """
@@ -220,7 +224,9 @@ interface, and records a CRC32c checksum of the source file's current contents (
 [`refresh_stale_test`](@ref) to detect edits before a rerun).
 """
 function build_eval_test(
-    blockinfo::TestBlockInfo, syntax_block::SyntaxBlock, pkg::PackageSpec
+    blockinfo::TestBlockInfo,
+    syntax_block::SyntaxBlock,
+    pkg::PackageSpec,
 )::EvalTest
     (; label, file_name, line_start) = blockinfo
     test_info = TestInfo(file_name, label, line_start)
@@ -233,7 +239,8 @@ function build_eval_test(
                 $(block_expr)
             end
         catch e
-            !(e isa Union{TestSetException,TestPicker.TestPickerTestSetException}) && rethrow()
+            !(e isa Union{TestSetException,TestPicker.TestPickerTestSetException}) &&
+                rethrow()
             TestPicker.save_test_results(e, $(test_info), $(pkg))
         end
     end
@@ -266,6 +273,54 @@ function testblock_list(
 end
 
 """
+    refresh_stale_test(test::EvalTest, pkg::PackageSpec) -> Union{Nothing,EvalTest}
+
+Re-locate a test block's source before rerunning it, if the file changed since capture.
+
+`test> -` normally replays the exact expression captured when the block was selected.
+If the source file was edited since then, that expression no longer reflects what's on
+disk. This compares a CRC32c checksum of the file's current contents against the one
+recorded on `test` (a content hash, rather than the modification time, so a real edit is
+never missed due to coarse mtime resolution or a save that happens to restore the
+original mtime). If the checksum changed, the whole file is re-parsed from scratch via
+[`build_info_to_syntax`](@ref) — the same routine used for the original selection, so
+every block's preamble is recomputed exactly as it would be for a fresh pick — and the
+block whose label aligns with `test`'s is looked up in the result.
+
+Whole-file tests (empty label, from `test> <file>`) are returned unchanged: they
+`include` the file, so they already see edits on rerun. If the file can no longer be
+found, if no block with a matching label exists anymore (renamed or removed), or if the
+label is now ambiguous (matches more than one block), there is no reliable way to know
+what to rerun: a warning is emitted and `nothing` is returned, so the stale test is
+dropped rather than silently re-running outdated code.
+"""
+function refresh_stale_test(test::EvalTest, pkg::PackageSpec)::Union{Nothing,EvalTest}
+    (; info) = test
+    isempty(info.label) && return test
+    root = get_test_dir_from_pkg(pkg)
+    path = joinpath(root, info.filename)
+    if !isfile(path)
+        @warn "File $(info.filename) could not be found anymore; dropping test block \"$(info.label)\" from the rerun."
+        return nothing
+    end
+    current_hash = crc32c(read(path))
+    current_hash == test.content_hash && return test
+
+    @info "File $(info.filename) was modified since test block \"$(info.label)\" was captured; refetching it from scratch."
+    info_to_syntax, _ = build_info_to_syntax(INTERFACES, root, [info.filename])
+    matches = filter(((blockinfo, _),) -> blockinfo.label == info.label, info_to_syntax)
+    if isempty(matches)
+        @warn "Test block \"$(info.label)\" could not be found anymore in $(info.filename); it may have been renamed or removed. Dropping it from the rerun."
+        return nothing
+    elseif length(matches) > 1
+        @warn "Test block \"$(info.label)\" now matches $(length(matches)) blocks in $(info.filename); cannot tell which one to rerun. Dropping it from the rerun."
+        return nothing
+    end
+    blockinfo, syntax_block = only(matches)
+    return build_eval_test(blockinfo, syntax_block, pkg)
+end
+
+"""
     fzf_testblock_from_files(interfaces, matched_files, fuzzy_testset, pkg, root; interactive::Bool=true) -> Nothing
 
 Test block selection and execution from a list of matched files.
@@ -282,7 +337,7 @@ function fzf_testblock_from_files(
     fuzzy_testset::AbstractString,
     pkg::PackageSpec,
     root::AbstractString;
-    interactive::Bool=true,
+    interactive::Bool = true,
 )
     # We create  the collection of testsets based on the list of files.
     info_to_syntax, display_to_info = build_info_to_syntax(interfaces, root, matched_files)
@@ -315,13 +370,18 @@ function fzf_testblock(
     interfaces::Vector{<:TestBlockInterface},
     fuzzy_file::AbstractString,
     fuzzy_testset::AbstractString;
-    interactive::Bool=true,
+    interactive::Bool = true,
 )
     pkg = current_pkg()
     root, testfiles = get_testfiles(pkg)
     # We fetch all valid test files.
     matched_files = get_matching_files(fuzzy_file, testfiles)
     fzf_testblock_from_files(
-        interfaces, matched_files, fuzzy_testset, pkg, root; interactive
+        interfaces,
+        matched_files,
+        fuzzy_testset,
+        pkg,
+        root;
+        interactive,
     )
 end

--- a/src/testblock.jl
+++ b/src/testblock.jl
@@ -216,7 +216,7 @@ end
 Build an executable [`EvalTest`](@ref) from a located test block.
 
 Wraps the block in a `TestPickerTestSet`, prepends any preamble required by its
-interface, and records the source file's current modification time (used by
+interface, and records a CRC32c checksum of the source file's current contents (used by
 [`refresh_stale_test`](@ref) to detect edits before a rerun).
 """
 function build_eval_test(
@@ -239,7 +239,8 @@ function build_eval_test(
     end
     preamble_statements = prepend_preamble_statements(interface, Expr.(preamble))
     ex = Expr(:block, preamble_statements..., tried_testset)
-    return EvalTest(ex, test_info, mtime(joinpath(root, file_name)))
+    content_hash = crc32c(read(joinpath(root, file_name)))
+    return EvalTest(ex, test_info, content_hash)
 end
 
 """

--- a/test/testblock.jl
+++ b/test/testblock.jl
@@ -1,5 +1,6 @@
 using Test
 using JuliaSyntax
+using Pkg.Types: PackageSpec
 using TestPicker
 using TestPicker: TestBlockInfo, StdTestset, SyntaxBlock, EvalResult
 using TestPicker:
@@ -9,7 +10,9 @@ using TestPicker:
     build_info_to_syntax,
     pick_testblock,
     istestblock,
-    fzf_testblock
+    fzf_testblock,
+    testblock_list,
+    refresh_stale_test
 
 function no_indentation(s::AbstractString)
     return replace(s, r"^\s+"m => "")
@@ -150,4 +153,86 @@ end
     result = fzf_testblock(interfaces, "test-a", "testset"; interactive=false)
     @test result isa Vector
     @test all(r -> r isa EvalResult, result)
+end
+
+@testset "Refreshing stale reruns" begin
+    # `root` must match `get_test_dir_from_pkg(pkg)` (the package's "test" directory),
+    # since `refresh_stale_test`/`build_eval_test` resolve the file's content hash from
+    # `pkg`.
+    root = joinpath(pkgdir(TestPicker), "test")
+    pkg = PackageSpec(; name="TestPicker", path=pkgdir(TestPicker))
+    interfaces = [StdTestset()]
+    file = "sandbox/test-rerun-tmp.jl"
+    path = joinpath(root, file)
+
+    write(
+        path,
+        """
+        using Test
+
+        @testset "rerun target" begin
+            @test true
+        end
+        """,
+    )
+    try
+        full_map, tabled_keys = build_info_to_syntax(interfaces, root, [file])
+        choices = pick_testblock(tabled_keys, "rerun target", root; interactive=false)
+        test = only(testblock_list(choices, full_map, tabled_keys, pkg))
+        @test test.info.line == 3
+
+        # Unmodified file: the exact same test is returned untouched.
+        @test refresh_stale_test(test, pkg) === test
+
+        # Modify the file so the same block now starts further down.
+        write(
+            path,
+            """
+            using Test
+
+            # A comment shifting the block down.
+
+            @testset "rerun target" begin
+                @test true
+            end
+            """,
+        )
+
+        refreshed = refresh_stale_test(test, pkg)
+        @test refreshed !== test
+        @test refreshed.info.line == 5
+        @test refreshed.info.label == "rerun target"
+
+        # If the label is now ambiguous, give up rather than guessing which block is meant
+        # — the stale test is dropped (`nothing`), not silently re-run.
+        write(
+            path,
+            """
+            using Test
+
+            @testset "rerun target" begin
+                @test true
+            end
+
+            @testset "rerun target" begin
+                @test true
+            end
+            """,
+        )
+        @test_logs (:warn,) match_mode = :any refresh_stale_test(refreshed, pkg)
+        @test isnothing(refresh_stale_test(refreshed, pkg))
+
+        # If the block can no longer be found, it's dropped too, instead of rerunning
+        # outdated code.
+        write(path, "using Test\n")
+        @test_logs (:warn,) match_mode = :any refresh_stale_test(refreshed, pkg)
+        @test isnothing(refresh_stale_test(refreshed, pkg))
+
+        # If the file itself disappears, same thing.
+        rm(path)
+        @test_logs (:warn,) match_mode = :any refresh_stale_test(refreshed, pkg)
+        @test isnothing(refresh_stale_test(refreshed, pkg))
+    finally
+        rm(path; force=true)
+    end
 end


### PR DESCRIPTION
Fix #41 

The approach is conservative:
- If the file does not exist / was moved: we drop the rerun
- If there are multiple matches for the label: we drop the rerun